### PR TITLE
Fix intersection observer

### DIFF
--- a/src/lib/components/shared/intersection_observer.svelte
+++ b/src/lib/components/shared/intersection_observer.svelte
@@ -13,6 +13,7 @@
     onMount(() => {
         if (typeof IntersectionObserver !== "undefined") {
             const rootMargin = `${bottom}px ${left}px ${top}px ${right}px`;
+
             const observer = new IntersectionObserver(
                 (entries) => {
                     intersecting = entries[0].isIntersecting;
@@ -24,12 +25,16 @@
                     rootMargin
                 }
             );
+
             observer.observe(container);
             return () => observer.unobserve(container);
         }
     });
 </script>
 
-<div bind:this={container}>
+<div
+    class="h-full w-full"
+    bind:this={container}
+>
     <slot {intersecting} />
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,7 +25,6 @@
     import Preference from "$icons/preference.svelte";
     import Recent from "$icons/recent.svelte";
     import SettingsOutline from "$icons/settings_outline.svelte";
-    import Star from "$icons/star.svelte";
     import { timer as timerStore } from "$store/timer";
     import { Timer as EasyTimer } from "easytimer.js";
     import _ from "lodash";
@@ -269,8 +268,8 @@
                                 alt={anime.name}
                             />
 
-                            <gradient-overlay class="absolute h-full w-full bg-gradient-to-t from-surface-900 to-surface-900/30 md:from-surface-900/95 md:to-surface-900/25" />
-                            <gradient-overlay class="absolute hidden h-full w-full bg-gradient-to-r from-surface-900 to-surface-900/25 md:flex md:from-surface-900/50" />
+                            <gradient-overlay class="absolute inset-0 bg-gradient-to-t from-surface-900 to-surface-900/30 md:from-surface-900/95 md:to-surface-900/25" />
+                            <gradient-overlay class="absolute inset-0 hidden bg-gradient-to-r from-surface-900 to-surface-900/25 md:flex md:from-surface-900/50" />
 
                             <div class="absolute bottom-0 px-[3vw] py-[2.625vw] md:px-[3.75vw]">
                                 <span class="text-3xl font-bold leading-[2.375vw] md:text-[2vw]">
@@ -403,7 +402,7 @@
                     <div class="relative h-[5vw]">
                         <ImageLoader
                             src={anime.cover}
-                            class="absolute h-full w-full rounded-[0.75vw] object-cover object-center "
+                            class="absolute h-full w-full rounded-[0.75vw] object-cover object-center"
                             alt={anime.name}
                         />
                         <gradient-overlay class="gradient absolute inset-0 bg-gradient-to-t from-surface-900/75 to-surface-900/0" />
@@ -478,10 +477,10 @@
                 class="absolute h-full w-full rounded-[0.875vw] border-[0.25vw] border-b-0 border-surface-50 object-cover object-center"
             />
 
-            <gradient-overlay class="gradient absolute h-full w-full bg-gradient-to-t from-surface-900 from-[1%] to-surface-900/25" />
-            <gradient-overlay class="gradient absolute h-full w-full bg-gradient-to-r from-surface-900/50 to-surface-900/25" />
+            <gradient-overlay class="gradient absolute inset-0 bg-gradient-to-t from-surface-900 from-[1%] to-surface-900/25" />
+            <gradient-overlay class="gradient absolute inset-0 bg-gradient-to-r from-surface-900/50 to-surface-900/25" />
 
-            <div class="absolute px-[1.875vw] pt-[2vw]">
+            <div class="absolute inset-0 px-[1.875vw] pt-[2vw]">
                 <div class="flex flex-col gap-[0.2w]">
                     <span class="text-[1.5vw] font-bold leading-[1vw]">Welcome</span>
                     <span class="text-[0.875vw] font-semibold leading-[2.5vw]">Jump quickly into</span>
@@ -595,7 +594,7 @@
                                         class="absolute h-full w-full rounded-[0.875vw] object-cover object-center"
                                     />
 
-                                    <gradient-overlay class=" absolute h-full w-full bg-gradient-to-t from-surface-900/90 to-surface-900/25 transition duration-300 group-hover:to-surface-900/75" />
+                                    <gradient-overlay class=" absolute inset-0 bg-gradient-to-t from-surface-900/90 to-surface-900/25 transition duration-300 group-hover:to-surface-900/75" />
 
                                     <div class="absolute inset-0 grid w-full grid-cols-1 place-items-center transition duration-300 group-hover:opacity-0">
                                         <span class="line-clamp-2 text-center text-[1vw] font-semibold leading-[1.35vw] text-white">


### PR DESCRIPTION
Fixed intersection observer issue regarding element height and width.

Problem: Observers only when target element is fully visible
Fix:
- Add `h-full` and `w-full` class to observer element
- Update siblings styles in `+page.svelte` file ( add `inset-0` )

Update: PR fixes #176 issue